### PR TITLE
build: make dependency bumps release-driving

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
 updates:
+  # Module bumps change what a consumer of the library resolves through MVS,
+  # so they are release-worthy: the `deps` prefix is a user-facing type in
+  # release-please-config.json and cuts a patch release.
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: deps
     groups:
       go-deps:
         patterns: ["*"]
@@ -11,10 +16,17 @@ updates:
     directory: /cmd
     schedule:
       interval: weekly
+    commit-message:
+      prefix: deps
     groups:
       go-deps:
         patterns: ["*"]
+  # Action bumps change nothing a consumer can observe, so they use `ci`,
+  # which is hidden and does not trigger a release. Without this they would
+  # default to `build(deps)` and cut a release for a CI-only change.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    commit-message:
+      prefix: ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,13 @@ release-please — a `feat` commit produces a minor bump, a `fix` a patch,
 and a breaking change a major bump (pre-1.0: minor). Write the subject as
 the changelog line a user should read.
 
+Dependency updates use `deps`, which is also release-driving: a module bump
+changes the versions a consumer of the library resolves through minimal
+version selection, so it belongs in the changelog and earns a patch release.
+Keep `ci` for GitHub Actions bumps — those change nothing a consumer can
+observe, and `ci` is hidden from the changelog and does not trigger a
+release. Dependabot is configured to use these prefixes automatically.
+
 ## Repository layout
 
 Two Go modules:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,21 @@
   "release-type": "go",
   "include-component-in-tag": false,
   "bump-minor-pre-major": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features" },
+    { "type": "feature", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "perf", "section": "Performance Improvements" },
+    { "type": "revert", "section": "Reverts" },
+    { "type": "deps", "section": "Dependencies" },
+    { "type": "build", "section": "Build System" },
+    { "type": "docs", "section": "Documentation", "hidden": true },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
+  ],
   "packages": {
     ".": {
       "package-name": "flatte",


### PR DESCRIPTION
The dependency refresh in `5362e69` landed on main but produced no release. The release-please run log is explicit:

```
✔ Considering: 2 commits
✔ No user facing commits found since e1455db… - skipping
```

`build` is a hidden, non-bumping type in release-please's defaults, so `v0.1.1` is still latest while `main` carries newer substrate pins.

## Why that classification was wrong

For a **library**, a module bump changes what a consumer resolves through minimal version selection — importing `flatte` now brings `lipgloss v2.0.5` and the newer `ultraviolet`. That is user-facing and belongs in the changelog.

## Changes

**`release-please-config.json`** — explicit `changelog-sections` making `deps` and `build` user-facing, keeping `docs`/`style`/`chore`/`refactor`/`test`/`ci` hidden. Naming `changelog-sections` replaces the defaults wholesale, which is why every type is listed rather than only the changed ones.

Because release-please evaluates every commit since the last release, this **retroactively** picks up the already-merged refresh — expect a `0.1.2` release PR once this lands. Nothing needs re-landing.

**`.github/dependabot.yml`** — Dependabot previously labelled *both* module and GitHub Actions updates `build(deps)`, so making `build` releasable alone would have cut a release for CI-only changes no consumer can observe. Each ecosystem now gets an explicit prefix: `gomod` → `deps` (release-driving), `github-actions` → `ci` (hidden).

**`CONTRIBUTING.md`** — documents both prefixes and why they differ.

## Verification

Config files are data, not code, so CI can only prove they don't break the build; the real proof is the release PR that should appear after merge. Both files were syntax-checked locally, and the visible/hidden split was confirmed to be: visible `feat, feature, fix, perf, revert, deps, build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)